### PR TITLE
Dynamic binding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,17 +61,22 @@ pub struct Polyhedron<'a> {
     shape: Box<RayCast<f64> + 'a>,
     color: image::Rgb<u8>,
     position: Isometry3<f64>,
+    // These will be turned on when we're done rendering multiple images.
     // reflectivity: f64,
     // refractivity: f64,
 }
 
 impl<'a> Polyhedron<'a> {
     #[inline]
-    pub fn new(shape: Box<RayCast<f64> + 'a>, color: image::Rgb<u8>) -> Self {
+    pub fn new(
+        shape: Box<RayCast<f64> + 'a>,
+        color: image::Rgb<u8>,
+        position: Isometry3<f64>,
+    ) -> Self {
         Polyhedron {
             shape,
             color,
-            position: Isometry3::identity(),
+            position,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
+// use nalgebra::base::unit::Unit;
 use nalgebra::geometry::Isometry3;
+use nalgebra::geometry::Translation3;
+use nalgebra::geometry::UnitQuaternion;
 use nalgebra::Vector3;
 use ncollide3d::math::Point;
 use ncollide3d::shape::*;
@@ -14,19 +17,31 @@ fn main() {
         std::f64::consts::PI / 2.0,
         (xsize, ysize),
     );
+    // A pair of example isometries. This is the way you express position of an object--
+    // Collision is checked between a ray (our camera's light ray) and a RayCast object (ie a
+    // sphere, cuboid, etc) under a certain isometry.
+    // The UnitQuaternion means no rotation. Quaternions are used widely in computer graphics to
+    // represent rotation. The Wikipedia: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+    // This object is at the origin, unrotated.
+    let position = Isometry3::from_parts(
+        Translation3::from(Vector3::new(0.0, 0.0, 0.0)),
+        UnitQuaternion::identity(),
+    );
+    // This object is at (0, 0, 3), unrotated.
+    let position2 = Isometry3::from_parts(
+        Translation3::from(Vector3::new(0.0, 0.0, 3.0)),
+        UnitQuaternion::identity(),
+    );
     // Note on building polyhedrons:
     // The position of the polyhedron must be noted as an isometry in 3d
-    // The RayCast objects needs to be implemented as an f64
+    // The RayCast object needs to be implemented as an f64
     let cube: Polyhedron = Polyhedron::new(
         Box::new(Cuboid::new(Vector3::new(1.0, 1.0, 1.0))),
         image::Rgb([0, 0, 0]),
-        Isometry3::identity(),
+        position,
     );
-    let sphere: Polyhedron = Polyhedron::new(
-        Box::new(Ball::new(2.0)),
-        image::Rgb([125, 0, 0]),
-        Isometry3::identity(),
-    );
+    let sphere: Polyhedron =
+        Polyhedron::new(Box::new(Ball::new(2.0)), image::Rgb([125, 0, 0]), position2);
     // This is an example scene
     let scene = Scene::new(vec![sphere, cube], view, image::Rgb([120, 120, 120]));
     scene.render("output.png".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,33 +8,33 @@ use ncollide3d::shape::*;
 use raytrace::*;
 
 fn main() {
-    let xsize = 500;
-    let ysize = 500;
+    let xsize = 640;
+    let ysize = 480;
     let view = Viewport::new(
-        Point::new(0.0, 0.0, 0.0),
+        Point::new(0.0, 10.0, 1.0),
         Vector3::new(0.0, -1.0, 0.0),
         Vector3::new(0.0, 0.0, 1.0),
         std::f64::consts::PI / 2.0,
         (xsize, ysize),
     );
-    // A pair of example isometries. This is the way you express position of an object--
-    // Collision is checked between a ray (our camera's light ray) and a RayCast object (ie a
+    // Example isometries. This is the way you express position of an object-- Collision is
+    // checked between a ray (our camera's light ray) and a RayCast object (ie a
     // sphere, cuboid, etc) under a certain isometry.
     // The UnitQuaternion means no rotation. Quaternions are used widely in computer graphics to
     // represent rotation. The Wikipedia: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
     // This object is at the origin, unrotated.
-    let position = Isometry3::from_parts(
-        Translation3::from(Vector3::new(0.0, 0.0, 0.0)),
-        UnitQuaternion::identity(),
-    );
     // This object is at (0, 0, 3), unrotated.
     let position2 = Isometry3::from_parts(
-        Translation3::from(Vector3::new(0.0, 0.0, 3.0)),
+        Translation3::from(Vector3::new(0.0, 0.0, 9.0)),
         UnitQuaternion::identity(),
     );
     // Note on building polyhedrons:
     // The position of the polyhedron must be noted as an isometry in 3d
     // The RayCast object needs to be implemented as an f64
+    let position = Isometry3::from_parts(
+        Translation3::from(Vector3::new(0.0, 0.0, 0.0)),
+        UnitQuaternion::identity(),
+    );
     let cube: Polyhedron = Polyhedron::new(
         Box::new(Cuboid::new(Vector3::new(1.0, 1.0, 1.0))),
         image::Rgb([0, 0, 0]),
@@ -43,6 +43,6 @@ fn main() {
     let sphere: Polyhedron =
         Polyhedron::new(Box::new(Ball::new(2.0)), image::Rgb([125, 0, 0]), position2);
     // This is an example scene
-    let scene = Scene::new(vec![sphere], view, image::Rgb([120, 120, 120]));
+    let scene = Scene::new(vec![sphere, cube], view, image::Rgb([120, 120, 120]));
     scene.render("output.png".to_string());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use nalgebra::geometry::Isometry3;
 use nalgebra::Vector3;
 use ncollide3d::math::Point;
 use ncollide3d::shape::*;
@@ -19,8 +20,13 @@ fn main() {
     let cube: Polyhedron = Polyhedron::new(
         Box::new(Cuboid::new(Vector3::new(1.0, 1.0, 1.0))),
         image::Rgb([0, 0, 0]),
+        Isometry3::identity(),
     );
-    let sphere: Polyhedron = Polyhedron::new(Box::new(Ball::new(2.0)), image::Rgb([125, 0, 0]));
+    let sphere: Polyhedron = Polyhedron::new(
+        Box::new(Ball::new(2.0)),
+        image::Rgb([125, 0, 0]),
+        Isometry3::identity(),
+    );
     // This is an example scene
     let scene = Scene::new(vec![sphere, cube], view, image::Rgb([120, 120, 120]));
     scene.render("output.png".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ fn main() {
     let xsize = 500;
     let ysize = 500;
     let view = Viewport::new(
-        Point::new(0.0, 5.0, 5.0),
-        Vector3::new(0.0, -1.0, -1.0),
+        Point::new(0.0, 0.0, 0.0),
+        Vector3::new(0.0, -1.0, 0.0),
         Vector3::new(0.0, 0.0, 1.0),
         std::f64::consts::PI / 2.0,
         (xsize, ysize),
@@ -43,6 +43,6 @@ fn main() {
     let sphere: Polyhedron =
         Polyhedron::new(Box::new(Ball::new(2.0)), image::Rgb([125, 0, 0]), position2);
     // This is an example scene
-    let scene = Scene::new(vec![sphere, cube], view, image::Rgb([120, 120, 120]));
+    let scene = Scene::new(vec![sphere], view, image::Rgb([120, 120, 120]));
     scene.render("output.png".to_string());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     let xsize = 500;
     let ysize = 500;
     let view = Viewport::new(
-        Point::new(2.0, 4.0, 4.0),
+        Point::new(0.0, 5.0, 5.0),
         Vector3::new(0.0, -1.0, -1.0),
         Vector3::new(0.0, 0.0, 1.0),
         std::f64::consts::PI / 2.0,
@@ -16,14 +16,12 @@ fn main() {
     // Note on building polyhedrons:
     // The position of the polyhedron must be noted as an isometry in 3d
     // The RayCast objects needs to be implemented as an f64
-    /*
-    let cube: Polyhedron<Cuboid<f64>> = Polyhedron::new(
-        Cuboid::new(Vector3::new(2.0, 2.0, 2.0)),
+    let cube: Polyhedron = Polyhedron::new(
+        Box::new(Cuboid::new(Vector3::new(1.0, 1.0, 1.0))),
         image::Rgb([0, 0, 0]),
     );
-    */
-    let sphere: Polyhedron<Ball<f64>> = Polyhedron::new(Ball::new(2.0), image::Rgb([125, 0, 0]));
+    let sphere: Polyhedron = Polyhedron::new(Box::new(Ball::new(2.0)), image::Rgb([125, 0, 0]));
     // This is an example scene
-    let scene = Scene::new(vec![sphere], view, image::Rgb([255, 255, 255]));
+    let scene = Scene::new(vec![sphere, cube], view, image::Rgb([120, 120, 120]));
     scene.render("output.png".to_string());
 }


### PR DESCRIPTION
Finishes the branch. Can now render multiple objects instead of just one.

The reason it was unable to render multiple objects was because it was overwriting the entire image every time it drew a new object. This fixes that through changes in `Scene::render(...)` (see last commit) and `Viewport::draw_ray(...)` (changes to return an Option tuple: distance and color).